### PR TITLE
Add permissions to the books service

### DIFF
--- a/books/permissions.py
+++ b/books/permissions.py
@@ -1,0 +1,9 @@
+﻿from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsAdminOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return bool(
+            request.method in SAFE_METHODS
+            or (request.user and request.user.is_staff)
+        )

--- a/libary_service/settings.py
+++ b/libary_service/settings.py
@@ -131,7 +131,10 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-    )
+    ),
+    "DEFAULT_PERMISSION_CLASSES": (
+        "books.permissions.IsAdminOrReadOnly",
+    ),
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
Only admin users can create/update/delete books

All users (even unauthenticated ones) should be able to list books

Use JWT token authentication from the users service